### PR TITLE
Treat SocketAsyncEventArgs.Completed with 0 bytes as an error

### DIFF
--- a/Redis.SilverlightGap/Redis.SilverlightClient/Sockets/SocketReceiver.cs
+++ b/Redis.SilverlightGap/Redis.SilverlightClient/Sockets/SocketReceiver.cs
@@ -46,8 +46,15 @@ namespace Redis.SilverlightClient.Sockets
         {
             if (socketEvent.SocketError == SocketError.Success)
             {
-                observer.OnNext(Encoding.UTF8.GetString(socketEvent.Buffer, 0, socketEvent.BytesTransferred));
-                observer.OnCompleted();
+                if (socketEvent.BytesTransferred == 0)
+                {
+                    observer.OnError(new InvalidOperationException("Received no bytes from Redis"));
+                }
+                else
+                {
+                    observer.OnNext(Encoding.UTF8.GetString(socketEvent.Buffer, 0, socketEvent.BytesTransferred));
+                    observer.OnCompleted();
+                }
             }
             else
             {      


### PR DESCRIPTION
@g-un-- can you take a look?

What happened was this: the Redis server started behaving weirdly, i.e. it accepted connections, but whenever the client sent a command it closed the connection. The result was that `SocketAsyncEventArgs.Completed` fired continuously, with `BytesTransferred` 0, which kept the processor completely busy. So I'm treating this case as an error. Is there a valid case where the Redis server sends empty messages?
